### PR TITLE
Add region parsing and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # openai
 
 Simple parser for travel offers with a small HTML interface. Assets are organized in `css/`, `js/` and `php/` folders.
+
+After parsing the pasted HTML list you can sort and filter the extracted data. A dropdown appears with all the available regions and you can enable or disable them via checkboxes. The table shows 200 entries by default.

--- a/css/style.css
+++ b/css/style.css
@@ -2,3 +2,15 @@ body { font-family: Arial, sans-serif; padding: 20px; }
 textarea { width: 100%; height: 200px; margin-bottom: 10px; }
 button { margin-right: 10px; padding: 10px 20px; }
 table { margin-top: 20px; width: 100%; border-collapse: collapse; }
+
+#filterContainer { display: inline-block; position: relative; }
+#filterDropdown {
+  display: none;
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 10px;
+  z-index: 100;
+}
+#filterContainer.show #filterDropdown { display: block; }
+label { display: block; }

--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
   <textarea id="inputText" placeholder="Inserisci testo o URL..."></textarea><br>
   <button id="parseBtn">Get Data</button>
   <button id="uploadBtn">Upload to DB</button>
+  <div id="filterContainer">
+    <button id="filterToggle">Filter</button>
+    <div id="filterDropdown"></div>
+  </div>
   <table id="results" class="display"></table>
 
 <script src="js/get_data.js"></script>


### PR DESCRIPTION
## Summary
- extract region, acronyms and airport codes while parsing
- allow filtering by region through a dropdown with checkboxes
- set default page length to 200 entries

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6862c7b199188322881df28584d40c6e